### PR TITLE
Update btif_media_task.c

### DIFF
--- a/btif/src/btif_media_task.c
+++ b/btif/src/btif_media_task.c
@@ -154,8 +154,8 @@ enum {
 #define BTIF_MEDIA_BITRATE_STEP 5
 #endif
 
-/* Middle quality quality setting @ 44.1 khz */
-#define DEFAULT_SBC_BITRATE 229
+/* High quality quality setting @ 44.1 khz */
+#define DEFAULT_SBC_BITRATE 328
 
 #ifndef A2DP_MEDIA_TASK_STACK_SIZE
 #define A2DP_MEDIA_TASK_STACK_SIZE       0x2000         /* In bytes */


### PR DESCRIPTION
Change middle quality to high quality for A2DP streaming to solve the issue of disortion in higher frequencies of music playback.  Refer to Android Google code issue 39632.
